### PR TITLE
Fix upload failing in release builds

### DIFF
--- a/lib/dropbox/upload.ts
+++ b/lib/dropbox/upload.ts
@@ -13,6 +13,7 @@ export const upload = async (
     localPath,
     {
       uploadType: FileSystem.FileSystemUploadType.BINARY_CONTENT,
+      sessionType: FileSystem.FileSystemSessionType.FOREGROUND,
       headers: {
         "Content-Type": "application/octet-stream",
         Authorization: `Bearer ${accessToken}`,

--- a/lib/gigafile/upload.ts
+++ b/lib/gigafile/upload.ts
@@ -14,6 +14,7 @@ export const upload = async (
     fileUri,
     {
       uploadType: FileSystem.FileSystemUploadType.MULTIPART,
+      sessionType: FileSystem.FileSystemSessionType.FOREGROUND,
       fieldName: "file",
       parameters: {
         id: Crypto.randomUUID(),


### PR DESCRIPTION
## Summary
- Use foreground URL sessions instead of background sessions for file uploads (Gigafile and Dropbox)
- Background sessions (`FileSystemSessionType.BACKGROUND`, the expo-file-system default) fail with `NSURLErrorDomain Code=-1 "unknown error"` in release builds
- Foreground sessions are appropriate here since the user is actively in the app waiting for the upload

## Test plan
- [x] Build with `npm run build:e2e:ios:local` and install on Simulator
- [x] Record audio and upload to Gigafile — verify upload completes successfully
- [x] Verify upload still works in dev mode (`npx expo run:ios`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)