### PR TITLE
Fix Dropbox upload failing in release builds

### DIFF
--- a/hooks/useDropboxOAuth.ts
+++ b/hooks/useDropboxOAuth.ts
@@ -42,9 +42,14 @@ export const useDropboxOAuth = (redirectPath: string) => {
 
   // issueAccessToken returns null when the process is canceled.
   const issueAccessToken = async (): Promise<TokenResponse | null> => {
-    const refreshToken = await SecureStore.getItemAsync(
-      DROPBOX_REFRESH_TOKEN_KEY
-    );
+    let refreshToken: string | null = null;
+    try {
+      refreshToken = await SecureStore.getItemAsync(
+        DROPBOX_REFRESH_TOKEN_KEY
+      );
+    } catch (e) {
+      console.error("Failed to read refresh token from SecureStore", e);
+    }
 
     if (refreshToken) {
       try {
@@ -78,10 +83,14 @@ export const useDropboxOAuth = (redirectPath: string) => {
           throw "Failed to get refresh token";
         }
 
-        await SecureStore.setItemAsync(
-          DROPBOX_REFRESH_TOKEN_KEY,
-          token.refreshToken
-        );
+        try {
+          await SecureStore.setItemAsync(
+            DROPBOX_REFRESH_TOKEN_KEY,
+            token.refreshToken
+          );
+        } catch (e) {
+          console.error("Failed to save refresh token to SecureStore", e);
+        }
 
         return token;
       case "cancel":


### PR DESCRIPTION
## Summary
- Wrap `SecureStore.getItemAsync` and `setItemAsync` calls in try-catch in the Dropbox OAuth flow
- If Keychain access fails (e.g., missing entitlement in Simulator release builds), the app falls through to the OAuth login flow instead of crashing with "A required entitlement isn't present"

## Test plan
- [x] Build a release build on iOS Simulator and verify Dropbox upload succeeds
- [ ] Verify Dropbox upload still works on a real device
- [ ] Verify re-authentication flow works when SecureStore is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)